### PR TITLE
Relabel wrapper performance arguments and clarify roles

### DIFF
--- a/R/input_validation.R
+++ b/R/input_validation.R
@@ -1,7 +1,7 @@
 validate_metric_constraints <- function(
   metric,
   target_performance,
-  tuning_performance = NULL
+  maximum_achievable_performance = NULL
 ) {
   metric_lower <- tolower(metric)
   metric_label <- switch(
@@ -28,28 +28,17 @@ validate_metric_constraints <- function(
   }
 
   if (
-    !is.null(tuning_performance) && metric_lower %in% c("auc", "r2", "cindex")
+    !is.null(maximum_achievable_performance) &&
+      metric_lower %in% c("auc", "r2", "cindex")
   ) {
-    if (tuning_performance < target_performance) {
+    if (target_performance >= maximum_achievable_performance) {
       stop(
         paste(
           "Requested target",
           metric_label,
-          "exceeds the tuning performance",
-          "(expected large-sample performance); adjust inputs and try again."
-        ),
-        call. = FALSE
-      )
-    }
-
-    if (isTRUE(all.equal(tuning_performance, target_performance))) {
-      warning(
-        paste(
-          "Target",
+          "must be less than the maximum achievable",
           metric_label,
-          "equals tuning performance.",
-          "These have different roles: tuning performance calibrates the data generator,",
-          "while target performance is the minimum acceptable developed-model performance."
+          "because both are specified on the same metric scale."
         ),
         call. = FALSE
       )

--- a/R/simulate_wrappers.R
+++ b/R/simulate_wrappers.R
@@ -3,7 +3,7 @@
 #' Compute the minimum sample size required to develop a prediction model with a
 #' binary outcome. The function wraps a simulation-based engine that combines a
 #' bisection search with Gaussian-process curve fitting. From user inputs
-#' (outcome prevalence, tuning performance, target performance, etc.) it
+#' (outcome prevalence, maximum achievable performance, target performance, etc.) it
 #' constructs a data-generating function, a model-fitting
 #' function, and a metric function, then searches for the smallest \eqn{n} that
 #' meets the chosen performance criterion.
@@ -35,9 +35,9 @@
 #'   the binary predictors when `predictor_type = "binary"`. Ignored otherwise.
 #' @param outcome_prevalence Numeric in (0, 1). Target prevalence of the binary
 #'   outcome in the intended modelling context.
-#' @param tuning_cstatistic Numeric in (0, 1). Tuning target for the expected
-#'   large-sample C-statistic. This calibrates the data-generating mechanism and
-#'   is not the minimum acceptable performance threshold.
+#' @param maximum_achievable_cstatistic Numeric in (0, 1). Maximum achievable
+#'   C-statistic with effectively unlimited data. This is used to calibrate the
+#'   data-generating mechanism and is not the minimum acceptable threshold.
 #' @param model Character string specifying the modelling algorithm (e.g.,
 #'   `"glm"`). Passed to the internal model generator.
 #' @param metric Character string naming the performance metric used to assess
@@ -68,7 +68,7 @@
 #'   noise_parameters = 10,
 #'   predictor_type = "continuous",
 #'   outcome_prevalence = 0.2,
-#'   tuning_cstatistic = 0.75,
+#'   maximum_achievable_cstatistic = 0.75,
 #'   metric = "calibration_slope",
 #'   target_performance = 0.9,
 #'   n_reps_total = 1000,
@@ -83,7 +83,7 @@ simulate_binary <- function(
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
   outcome_prevalence, # Outcome
-  tuning_cstatistic,
+  maximum_achievable_cstatistic,
   model = "glm", # Model
   metric = "calibration_slope", # Performance
   target_performance,
@@ -94,13 +94,13 @@ simulate_binary <- function(
   validate_metric_constraints(
     metric = metric,
     target_performance = target_performance,
-    tuning_performance = tuning_cstatistic
+    maximum_achievable_performance = maximum_achievable_cstatistic
   )
 
   # Tune for data function
   tune_param <- binary_tuning(
     target_prevalence = outcome_prevalence,
-    target_performance = tuning_cstatistic,
+    target_performance = maximum_achievable_cstatistic,
     candidate_features = signal_parameters + noise_parameters,
     proportion_noise_features = noise_parameters /
       (signal_parameters + noise_parameters)
@@ -130,7 +130,7 @@ simulate_binary <- function(
     output <- simulate_custom(
       metric_function = default_metric_generator(metric, data_function),
       target_performance = target_performance,
-      c_statistic = tuning_cstatistic,
+      c_statistic = maximum_achievable_cstatistic,
       data_function = data_function,
       model_function = model_function,
       min_sample_size = NULL,
@@ -162,7 +162,7 @@ simulate_binary <- function(
   output$predictor_type <- predictor_type
   output$binary_predictor_prevalence <- output$predictor_type
   output$prevalence <- outcome_prevalence
-  output$cstatistic <- tuning_cstatistic
+  output$cstatistic <- maximum_achievable_cstatistic
   output$model <- model
   output$metric <- metric
   output$n_reps_total <- n_reps_total
@@ -177,7 +177,7 @@ simulate_binary <- function(
 #' Compute the minimum sample size required to develop a prediction model with a
 #' **continuous** outcome. This wraps the same simulation engine as
 #' [simulate_binary()], combining bisection search with Gaussian-process
-#' learning-curve modelling. From user inputs (tuning performance, target
+#' learning-curve modelling. From user inputs (maximum achievable performance, target
 #' performance, etc.) it constructs a
 #' data-generating function, model-fitting function, and metric function, then
 #' searches for the smallest \eqn{n} meeting the chosen criterion.
@@ -185,9 +185,9 @@ simulate_binary <- function(
 #' @inheritSection simulate_binary Criteria
 #'
 #' @inheritParams simulate_binary
-#' @param tuning_rsquared Numeric in (0, 1). Tuning target for expected
-#'   large-sample \eqn{R^2}. This calibrates the data-generating mechanism and
-#'   is not the minimum acceptable performance threshold.
+#' @param maximum_achievable_rsquared Numeric in (0, 1). Maximum achievable
+#'   \eqn{R^2} with effectively unlimited data. This is used to calibrate the
+#'   data-generating mechanism and is not the minimum acceptable threshold.
 #'
 #' @return An object of class `"pmsims"` containing the estimated minimum sample
 #'   size and simulation diagnostics (inputs, fitted GP curve, intermediate
@@ -201,7 +201,7 @@ simulate_binary <- function(
 #'   signal_parameters = 8,
 #'   noise_parameters = 8,
 #'   predictor_type = "continuous",
-#'   tuning_rsquared = 0.50,
+#'   maximum_achievable_rsquared = 0.50,
 #'   metric = "calibration_slope",
 #'   target_performance = 0.9,
 #'   n_reps_total = 1000,
@@ -215,7 +215,7 @@ simulate_continuous <- function(
   noise_parameters = 0,
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
-  tuning_rsquared,
+  maximum_achievable_rsquared,
   model = "lm",
   metric = "calibration_slope",
   target_performance,
@@ -226,12 +226,12 @@ simulate_continuous <- function(
   validate_metric_constraints(
     metric = metric,
     target_performance = target_performance,
-    tuning_performance = tuning_rsquared
+    maximum_achievable_performance = maximum_achievable_rsquared
   )
 
   # Tuning the data-generating function
   tune_param <- continuous_tuning(
-    r2 = tuning_rsquared,
+    r2 = maximum_achievable_rsquared,
     candidate_features = signal_parameters + noise_parameters,
     proportion_noise_features = noise_parameters /
       (signal_parameters + noise_parameters)
@@ -258,7 +258,7 @@ simulate_continuous <- function(
     output <- simulate_custom(
       metric_function = default_metric_generator(metric, data_function),
       target_performance = target_performance,
-      c_statistic = tuning_rsquared,
+      c_statistic = maximum_achievable_rsquared,
       data_function = data_function,
       model_function = model_function,
       min_sample_size = NULL,
@@ -289,7 +289,7 @@ simulate_continuous <- function(
   output$noise_parameters <- noise_parameters
   output$predictor_type <- predictor_type
   output$binary_predictor_prevalence <- output$predictor_type
-  output$r2 <- tuning_rsquared
+  output$r2 <- maximum_achievable_rsquared
   output$model <- model
   output$metric <- metric
   output$n_reps_total <- n_reps_total
@@ -309,9 +309,9 @@ simulate_continuous <- function(
 #' @inheritSection simulate_binary Criteria
 #'
 #' @inheritParams simulate_binary
-#' @param tuning_cindex Numeric in (0, 1). Tuning target for expected
-#'   large-sample C-index. This calibrates the data-generating mechanism and is
-#'   not the minimum acceptable performance threshold.
+#' @param maximum_achievable_cindex Numeric in (0, 1). Maximum achievable
+#'   C-index with effectively unlimited data. This is used to calibrate the
+#'   data-generating mechanism and is not the minimum acceptable threshold.
 #' @param baseline_hazard Numeric greater than 0. Baseline hazard level used by the
 #'   data-generating mechanism (e.g., the constant hazard in an exponential
 #'   baseline). Larger values imply shorter event times, all else equal.
@@ -332,7 +332,7 @@ simulate_continuous <- function(
 #'   signal_parameters = 10,
 #'   noise_parameters = 10,
 #'   predictor_type = "continuous",
-#'   tuning_cindex = 0.70,
+#'   maximum_achievable_cindex = 0.70,
 #'   baseline_hazard = 0.01,
 #'   censoring_rate = 0.30,
 #'   metric = "calibration_slope",
@@ -348,7 +348,7 @@ simulate_survival <- function(
   noise_parameters = 0,
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
-  tuning_cindex,
+  maximum_achievable_cindex,
   baseline_hazard = 1,
   censoring_rate,
   model = "coxph",
@@ -361,13 +361,13 @@ simulate_survival <- function(
   validate_metric_constraints(
     metric = metric,
     target_performance = target_performance,
-    tuning_performance = tuning_cindex
+    maximum_achievable_performance = maximum_achievable_cindex
   )
 
   # Tune the data-generating function
   tune_param <- survival_tuning(
     target_prevalence = 1 - censoring_rate,
-    target_performance = tuning_cindex,
+    target_performance = maximum_achievable_cindex,
     candidate_features = signal_parameters + noise_parameters,
     proportion_noise_features = noise_parameters /
       (signal_parameters + noise_parameters)
@@ -396,7 +396,7 @@ simulate_survival <- function(
     output <- simulate_custom(
       metric_function = default_metric_generator(metric, data_function),
       target_performance = target_performance,
-      c_statistic = tuning_cindex,
+      c_statistic = maximum_achievable_cindex,
       data_function = data_function,
       model_function = model_function,
       min_sample_size = NULL,
@@ -430,7 +430,7 @@ simulate_survival <- function(
   output$binary_predictor_prevalence <- output$predictor_type
   output$baseline_hazard <- baseline_hazard
   output$censoring_rate <- censoring_rate
-  output$cstatistic <- tuning_cindex
+  output$cstatistic <- maximum_achievable_cindex
   output$model <- model
   output$metric <- metric
   output$n_reps_total <- n_reps_total

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,7 @@ binary_example <- simulate_binary(
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
   outcome_prevalence = 0.20,
-  tuning_cstatistic = 0.80,
+  maximum_achievable_cstatistic = 0.80,
   model = "glm",
   metric = "calibration_slope",
   target_performance = 0.90,
@@ -66,9 +66,9 @@ binary_example <- simulate_binary(
 binary_example
 ```
 
-`tuning_cstatistic` and `target_performance` have different roles:
+`maximum_achievable_cstatistic` and `target_performance` have different roles:
 
-- `tuning_cstatistic` calibrates the data generator to a plausible large-sample performance level.
+- `maximum_achievable_cstatistic` represents the best plausible C-statistic with effectively unlimited data and calibrates the data generator.
 - `target_performance` is the minimum acceptable metric value used to determine the required sample size.
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ binary_example <- simulate_binary(
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
   outcome_prevalence = 0.20,
-  tuning_cstatistic = 0.80,
+  maximum_achievable_cstatistic = 0.80,
   model = "glm",
   metric = "calibration_slope",
   target_performance = 0.90,
@@ -56,9 +56,9 @@ binary_example <- simulate_binary(
 binary_example
 ```
 
-`tuning_cstatistic` and `target_performance` have different roles:
+`maximum_achievable_cstatistic` and `target_performance` have different roles:
 
-- `tuning_cstatistic` calibrates the data generator to a plausible large-sample performance level.
+- `maximum_achievable_cstatistic` represents the best plausible C-statistic with effectively unlimited data and calibrates the data generator.
 - `target_performance` is the minimum acceptable metric value used to determine the required sample size.
 
 ------------------------------------------------------------------------

--- a/man/simulate_binary.Rd
+++ b/man/simulate_binary.Rd
@@ -10,7 +10,7 @@ simulate_binary(
   predictor_type = c("continuous"),
   binary_predictor_prevalence = NULL,
   outcome_prevalence,
-  tuning_cstatistic,
+  maximum_achievable_cstatistic,
   model = c("glm"),
   metric = c("calibration_slope", "auc"),
   target_performance,
@@ -35,9 +35,9 @@ the binary predictors when \code{predictor_type = "binary"}. Ignored otherwise.}
 \item{outcome_prevalence}{Numeric in (0, 1). Target prevalence of the binary
 outcome in the intended modelling context.}
 
-\item{tuning_cstatistic}{Numeric in (0, 1). Tuning target for the expected
-large-sample C-statistic. This calibrates the data-generating mechanism and
-is not the minimum acceptable performance threshold.}
+\item{maximum_achievable_cstatistic}{Numeric in (0, 1). Maximum achievable
+C-statistic with effectively unlimited data. This is used to calibrate the
+data-generating mechanism and is not the minimum acceptable threshold.}
 
 \item{model}{Character string specifying the modelling algorithm (e.g.,
 \code{"glm"}). Passed to the internal model generator.}
@@ -70,7 +70,7 @@ evaluations, and summary metrics).
 Compute the minimum sample size required to develop a prediction model with a
 binary outcome. The function wraps a simulation-based engine that combines a
 bisection search with Gaussian-process curve fitting. From user inputs
-(outcome prevalence, tuning performance, target performance, etc.) it
+(outcome prevalence, maximum achievable performance, target performance, etc.) it
 constructs a data-generating function, a model-fitting
 function, and a metric function, then searches for the smallest \eqn{n} that
 meets the chosen performance criterion.
@@ -101,7 +101,7 @@ est <- simulate_binary(
   noise_parameters = 10,
   predictor_type = "continuous",
   outcome_prevalence = 0.2,
-  tuning_cstatistic = 0.75,
+  maximum_achievable_cstatistic = 0.75,
   metric = "calibration_slope",
   target_performance = 0.9,
   n_reps_total = 1000,

--- a/man/simulate_continuous.Rd
+++ b/man/simulate_continuous.Rd
@@ -9,7 +9,7 @@ simulate_continuous(
   noise_parameters = 0,
   predictor_type = c("continuous"),
   binary_predictor_prevalence = NULL,
-  tuning_rsquared,
+  maximum_achievable_rsquared,
   model = c("lm"),
   metric = c("calibration_slope", "r2"),
   target_performance,
@@ -31,9 +31,9 @@ Specifies the type of simulated candidate predictors.}
 \item{binary_predictor_prevalence}{Optional numeric in (0, 1). Prevalence of
 the binary predictors when \code{predictor_type = "binary"}. Ignored otherwise.}
 
-\item{tuning_rsquared}{Numeric in (0, 1). Tuning target for expected
-large-sample \eqn{R^2}. This calibrates the data-generating mechanism and
-is not the minimum acceptable performance threshold.}
+\item{maximum_achievable_rsquared}{Numeric in (0, 1). Maximum achievable
+\eqn{R^2} with effectively unlimited data. This is used to calibrate the
+data-generating mechanism and is not the minimum acceptable threshold.}
 
 \item{model}{Character string specifying the modelling algorithm (e.g.,
 \code{"glm"}). Passed to the internal model generator.}
@@ -66,7 +66,7 @@ evaluations, and summary metrics).
 Compute the minimum sample size required to develop a prediction model with a
 \strong{continuous} outcome. This wraps the same simulation engine as
 \code{\link[=simulate_binary]{simulate_binary()}}, combining bisection search with Gaussian-process
-learning-curve modelling. From user inputs (tuning performance, target
+learning-curve modelling. From user inputs (maximum achievable performance, target
 performance, etc.) it constructs a
 data-generating function, model-fitting function, and metric function, then
 searches for the smallest \eqn{n} meeting the chosen criterion.
@@ -96,7 +96,7 @@ est <- simulate_continuous(
   signal_parameters = 8,
   noise_parameters = 8,
   predictor_type = "continuous",
-  tuning_rsquared = 0.50,
+  maximum_achievable_rsquared = 0.50,
   metric = "calibration_slope",
   target_performance = 0.9,
   n_reps_total = 1000,

--- a/man/simulate_survival.Rd
+++ b/man/simulate_survival.Rd
@@ -9,7 +9,7 @@ simulate_survival(
   noise_parameters = 0,
   predictor_type = c("continuous"),
   binary_predictor_prevalence = NULL,
-  tuning_cindex,
+  maximum_achievable_cindex,
   baseline_hazard = 1,
   censoring_rate,
   model = c("coxph"),
@@ -33,9 +33,9 @@ Specifies the type of simulated candidate predictors.}
 \item{binary_predictor_prevalence}{Optional numeric in (0, 1). Prevalence of
 the binary predictors when \code{predictor_type = "binary"}. Ignored otherwise.}
 
-\item{tuning_cindex}{Numeric in (0, 1). Tuning target for expected
-large-sample C-index. This calibrates the data-generating mechanism and is
-not the minimum acceptable performance threshold.}
+\item{maximum_achievable_cindex}{Numeric in (0, 1). Maximum achievable
+C-index with effectively unlimited data. This is used to calibrate the
+data-generating mechanism and is not the minimum acceptable threshold.}
 
 \item{baseline_hazard}{Numeric greater than 0. Baseline hazard level used by the
 data-generating mechanism (e.g., the constant hazard in an exponential
@@ -103,7 +103,7 @@ est <- simulate_survival(
   signal_parameters = 10,
   noise_parameters = 10,
   predictor_type = "continuous",
-  tuning_cindex = 0.70,
+  maximum_achievable_cindex = 0.70,
   baseline_hazard = 0.01,
   censoring_rate = 0.30,
   metric = "calibration_slope",

--- a/tests/testthat/test-simulate_wrappers.R
+++ b/tests/testthat/test-simulate_wrappers.R
@@ -7,7 +7,7 @@ test_that("simulate_binary returns a pmsims object", {
     noise_parameters = 0,
     predictor_type = "continuous",
     outcome_prevalence = 0.2,
-    tuning_cstatistic = 0.75,
+    maximum_achievable_cstatistic = 0.75,
     metric = "calibration_slope",
     target_performance = 0.9,
     n_reps_total = 1000,
@@ -29,7 +29,7 @@ test_that("simulate_continuous returns a pmsims object", {
     signal_parameters = 10,
     noise_parameters = 0,
     predictor_type = "continuous",
-    tuning_rsquared = 0.5,
+    maximum_achievable_rsquared = 0.5,
     metric = "calibration_slope",
     target_performance = 0.9,
     n_reps_total = 1000,
@@ -51,7 +51,7 @@ test_that("simulate_survival returns a pmsims object", {
     signal_parameters = 10,
     noise_parameters = 0,
     predictor_type = "continuous",
-    tuning_cindex = 0.75,
+    maximum_achievable_cindex = 0.75,
     baseline_hazard = 0.01,
     censoring_rate = 0.3,
     metric = "calibration_slope",
@@ -74,7 +74,7 @@ test_that("wrapper calibration slope bounds are enforced", {
       noise_parameters = 0,
       predictor_type = "continuous",
       outcome_prevalence = 0.2,
-      tuning_cstatistic = 0.75,
+      maximum_achievable_cstatistic = 0.75,
       metric = "calibration_slope",
       target_performance = 0.7,
       n_reps_total = 1000,
@@ -89,7 +89,7 @@ test_that("wrapper calibration slope bounds are enforced", {
       signal_parameters = 10,
       noise_parameters = 0,
       predictor_type = "continuous",
-      tuning_rsquared = 0.5,
+      maximum_achievable_rsquared = 0.5,
       metric = "calibration_slope",
       target_performance = 1.3,
       n_reps_total = 1000,
@@ -104,7 +104,7 @@ test_that("wrapper calibration slope bounds are enforced", {
       signal_parameters = 10,
       noise_parameters = 0,
       predictor_type = "continuous",
-      tuning_cindex = 0.75,
+      maximum_achievable_cindex = 0.75,
       baseline_hazard = 0.01,
       censoring_rate = 0.3,
       metric = "calibration_slope",
@@ -124,13 +124,31 @@ test_that("simulate_binary requires achievable AUC targets", {
       noise_parameters = 0,
       predictor_type = "continuous",
       outcome_prevalence = 0.2,
-      tuning_cstatistic = 0.80,
+      maximum_achievable_cstatistic = 0.80,
       metric = "auc",
       target_performance = 0.9,
       n_reps_total = 1000,
       mean_or_assurance = "assurance"
     ),
-    "Requested target AUC exceeds the tuning performance (expected large-sample performance); adjust inputs and try again.",
+    "Requested target AUC must be less than the maximum achievable AUC because both are specified on the same metric scale.",
+    fixed = TRUE
+  )
+})
+
+test_that("simulate_binary errors when maximum achievable AUC equals target", {
+  expect_error(
+    simulate_binary(
+      signal_parameters = 10,
+      noise_parameters = 0,
+      predictor_type = "continuous",
+      outcome_prevalence = 0.2,
+      maximum_achievable_cstatistic = 0.8,
+      metric = "auc",
+      target_performance = 0.8,
+      n_reps_total = 1000,
+      mean_or_assurance = "assurance"
+    ),
+    "Requested target AUC must be less than the maximum achievable AUC because both are specified on the same metric scale.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -51,9 +51,9 @@ test_that("validate_metric_constraints enforces calibration slope limits", {
     validate_metric_constraints(
       metric = "auc",
       target_performance = 0.8,
-      tuning_performance = 0.75
+      maximum_achievable_performance = 0.75
     ),
-    "Requested target AUC exceeds the tuning performance (expected large-sample performance); adjust inputs and try again.",
+    "Requested target AUC must be less than the maximum achievable AUC because both are specified on the same metric scale.",
     fixed = TRUE
   )
 
@@ -61,29 +61,51 @@ test_that("validate_metric_constraints enforces calibration slope limits", {
     validate_metric_constraints(
       metric = "auc",
       target_performance = 0.75,
-      tuning_performance = 0.8
+      maximum_achievable_performance = 0.8
     )
   )
 })
 
-test_that("validate_metric_constraints warns when tuning and target are equal", {
-  expect_warning(
+test_that("validate_metric_constraints errors when maximum achievable equals target", {
+  expect_error(
     validate_metric_constraints(
       metric = "auc",
       target_performance = 0.8,
-      tuning_performance = 0.8
+      maximum_achievable_performance = 0.8
     ),
-    "Target AUC equals tuning performance.",
+    "Requested target AUC must be less than the maximum achievable AUC because both are specified on the same metric scale.",
     fixed = TRUE
   )
 })
 
-test_that("validate_metric_constraints does not warn for non-comparable metrics", {
+test_that("validate_metric_constraints errors for equal or higher target on r2 and cindex", {
+  expect_error(
+    validate_metric_constraints(
+      metric = "r2",
+      target_performance = 0.6,
+      maximum_achievable_performance = 0.6
+    ),
+    "Requested target R2 must be less than the maximum achievable R2 because both are specified on the same metric scale.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    validate_metric_constraints(
+      metric = "cindex",
+      target_performance = 0.76,
+      maximum_achievable_performance = 0.75
+    ),
+    "Requested target C-index must be less than the maximum achievable C-index because both are specified on the same metric scale.",
+    fixed = TRUE
+  )
+})
+
+test_that("validate_metric_constraints does not compare non-comparable metrics", {
   expect_silent(
     validate_metric_constraints(
       metric = "calibration_slope",
       target_performance = 0.9,
-      tuning_performance = 0.9
+      maximum_achievable_performance = 0.9
     )
   )
 })

--- a/vignettes/pmsims.Rmd
+++ b/vignettes/pmsims.Rmd
@@ -162,9 +162,9 @@ lists the key inputs.
     </tr>
 
     <tr>
-      <td><strong><code>tuning_cstatistic</code></strong></td>
+      <td><strong><code>maximum_achievable_cstatistic</code></strong></td>
       <td>
-        <em>(num 0–1)</em> Tuning target for the expected <strong>C-statistic</strong> with effectively unlimited data.
+        <em>(num 0–1)</em> Maximum achievable <strong>C-statistic</strong> with effectively unlimited data.
         This calibrates the data generator and is not the minimum acceptable threshold.
         <div class="meta">
           <span class="badge badge--scope">Applies: binary only</span>
@@ -175,9 +175,9 @@ lists the key inputs.
     </tr>
 
     <tr>
-      <td><strong><code>tuning_rsquared</code></strong></td>
+      <td><strong><code>maximum_achievable_rsquared</code></strong></td>
       <td>
-        <em>(num 0–1)</em> Tuning target for expected large-sample R<sup>2</sup>.
+        <em>(num 0–1)</em> Maximum achievable R<sup>2</sup> with effectively unlimited data.
         This calibrates the data generator and is not the minimum acceptable threshold.
         <div class="meta">
           <span class="badge badge--scope">Applies: continuous only</span>
@@ -188,9 +188,9 @@ lists the key inputs.
     </tr>
 
     <tr>
-      <td><strong><code>tuning_cindex</code></strong></td>
+      <td><strong><code>maximum_achievable_cindex</code></strong></td>
       <td>
-        <em>(num 0–1)</em> Tuning target for expected large-sample <strong>concordance index</strong>.
+        <em>(num 0–1)</em> Maximum achievable <strong>concordance index</strong> with effectively unlimited data.
         This calibrates the data generator and is not the minimum acceptable threshold.
         <div class="meta">
           <span class="badge badge--scope">Applies: survival only</span>
@@ -264,8 +264,8 @@ lists the key inputs.
 
 > Notes:
 >
-> - `tuning_*` calibrates the data generator to a plausible **large-sample**
->   performance level.
+> - `maximum_achievable_*` represents the best plausible performance with
+>   effectively unlimited data and calibrates the data generator.
 > - `target_performance` is the minimum acceptable performance threshold used
 >   to determine the required sample size.
 > - For reproducibility, set a random seed (`set.seed()`).
@@ -293,7 +293,7 @@ binary_example <- simulate_binary(
   predictor_type = "continuous",
   binary_predictor_prevalence = NULL,
   outcome_prevalence = 0.30,
-  tuning_cstatistic = 0.80,
+  maximum_achievable_cstatistic = 0.80,
   model = "glm",
   metric = "calibration_slope",
   target_performance = 0.85,
@@ -316,7 +316,7 @@ if (use_cache) {
     predictor_type = "continuous",
     binary_predictor_prevalence = NULL,
     outcome_prevalence = 0.30,
-    tuning_cstatistic = 0.80,
+    maximum_achievable_cstatistic = 0.80,
     model = "glm",
     metric = "calibration_slope",
     target_performance = 0.85,
@@ -345,7 +345,7 @@ continuous_example <- simulate_continuous(
   signal_parameters = 15,
   noise_parameters = 0,
   predictor_type = "continuous",
-  tuning_rsquared = 0.50,
+  maximum_achievable_rsquared = 0.50,
   model = "lm",
   metric = "calibration_slope",
   target_performance = 0.90,
@@ -366,7 +366,7 @@ if (use_cache) {
     signal_parameters = 15,
     noise_parameters = 0,
     predictor_type = "continuous",
-    tuning_rsquared = 0.50,
+    maximum_achievable_rsquared = 0.50,
     model = "lm",
     metric = "calibration_slope",
     target_performance = 0.90,


### PR DESCRIPTION
## Summary
- rename wrapper args to maximum_achievable_* and keep target_performance
- keep current argument ordering
- change same-metric validation so target_performance must be strictly less than the maximum achievable auc/r2/cindex
- update tests and user-facing docs/examples to the new API names and terminology

## Advisory Group Context
- Discussed at the advisory group meeting last week; this is an initial pass based on that discussion.
- Minutes action item: "Clarify documentation and interface wording on "large sample performance" vs "minimum acceptable/target performance", including guidance on how to choose values. (Owner: team)."
- Final argument labels may still change after team review and consensus.
- This PR also serves as a test of our GitHub workflow: create a feature branch from dev, raise a PR, and have it reviewed by another team member.

## Notes
- breaking API rename by design (no compatibility aliases)
- same-metric target values now error when they are equal to or greater than the maximum achievable value
- requesting team review before finalizing the label wording