### PR TITLE
Remove duplicate find.design() call in calculate_mlpwr()

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -255,21 +255,6 @@ calculate_mlpwr <- function(
     }
   )
 
-  ds <-
-    mlpwr::find.design(
-      simfun = mlpwr_simulation_function,
-      aggregate_fun = aggregate_fun,
-      noise_fun = noise_fun,
-      boundaries = c(start_min_sample_size, start_max_sample_size),
-      power = target_performance,
-      surrogate = "gpr",
-      setsize = n_reps_per,
-      evaluations = n_reps_total,
-      ci = ci,
-      n.startsets = n_init,
-      silent = !isTRUE(progress)
-    )
-
   # Process results from mlpwr
   perfs <- ds$dat
   perfs <- perfs[order(sapply(perfs, "[[", "x"))]

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -42,6 +42,65 @@ test_that("calculate_mlpwr", {
   expect_true(is.numeric(output_assurance$min_n))
 })
 
+test_that("calculate_mlpwr calls mlpwr::find.design once", {
+  calls <- 0L
+
+  local_mocked_bindings(
+    compute_start_sample_sizes = function(...) {
+      list(start_min_sample_size = 50)
+    },
+    calculate_adaptive_bounds = function(...) {
+      list(min_sample_size = 50, max_sample_size = 100)
+    },
+    get_summaries = function(...) {
+      list(mean = 0.8)
+    },
+    .package = "pmsims"
+  )
+
+  local_mocked_bindings(
+    find.design = function(...) {
+      calls <<- calls + 1L
+      list(
+        dat = list(list(x = 50, y = c(0.79, 0.81))),
+        fit = list(),
+        boundaries = c(50, 100),
+        final = list(design = 50, power = 0.8),
+        aggregate_fun = function(x) mean(x, na.rm = TRUE)
+      )
+    },
+    .package = "mlpwr"
+  )
+
+  data_function <- function(n) data.frame(y = rep(0, n), x1 = rep(0, n))
+  model_function <- function(data) NULL
+  metric_function <- function(test_data, fit, model) 0.8
+  attr(model_function, "model") <- "glm"
+  attr(metric_function, "metric") <- "auc"
+
+  output <- calculate_mlpwr(
+    test_n = 100,
+    n_reps_total = 20,
+    n_reps_per = 5,
+    se_final = NULL,
+    min_sample_size = 50,
+    max_sample_size = 100,
+    target_performance = 0.75,
+    c_statistic = 0.8,
+    mean_or_assurance = "mean",
+    n_init = 4,
+    progress = FALSE,
+    verbose = FALSE,
+    data_function = data_function,
+    model_function = model_function,
+    metric_function = metric_function,
+    value_on_error = 0.5
+  )
+
+  expect_identical(calls, 1L)
+  expect_identical(output$min_n, 50)
+})
+
 test_that("calculate_mlpwr_bs", {
   set.seed(1234)
   functions <- get_binary_data_model_metric()


### PR DESCRIPTION
Remove duplicate stage-two `mlpwr::find.design()` call in `calculate_mlpwr()`. Keep the existing `tryCatch`-wrapped search and add a regression test to ensure the Gaussian-process search runs exactly once. This removes unnecessary post-stage-two delay without changing the vignette example outputs between `main` and `fixes/duplicate-ds`.